### PR TITLE
Implement basic synchronized video playback MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Synchronized Video Stream
+
+Simple Flask application that lets multiple users watch the same video in sync.
+
+## Setup
+
+Install dependencies (preferably in a virtualenv):
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the server:
+
+```bash
+python app.py
+```
+
+Open `http://localhost:5000` in several browser tabs to test synchronization.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,52 @@
+import time
+from flask import Flask, render_template
+from flask_socketio import SocketIO, emit
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'secret!'
+socketio = SocketIO(app)
+
+state = {
+    'is_playing': False,
+    'current_time': 0.0,
+    'last_update': time.time()
+}
+
+
+def get_current_time():
+    if state['is_playing']:
+        return state['current_time'] + (time.time() - state['last_update'])
+    return state['current_time']
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@socketio.on('connect')
+def on_connect():
+    emit('sync', {
+        'is_playing': state['is_playing'],
+        'current_time': get_current_time()
+    })
+
+
+@socketio.on('play')
+def on_play(data):
+    state['is_playing'] = True
+    state['current_time'] = data.get('current_time', 0.0)
+    state['last_update'] = time.time()
+    emit('play', {'current_time': state['current_time']}, broadcast=True, include_self=False)
+
+
+@socketio.on('pause')
+def on_pause(data):
+    state['is_playing'] = False
+    state['current_time'] = data.get('current_time', 0.0)
+    state['last_update'] = time.time()
+    emit('pause', {'current_time': state['current_time']}, broadcast=True, include_self=False)
+
+
+if __name__ == '__main__':
+    socketio.run(app, host='0.0.0.0', port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask==2.3.2
+Flask-SocketIO==5.3.3
+python-socketio==4.6.1

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,18 @@
+body {
+    background-color: #222;
+    color: #eee;
+    font-family: Arial, sans-serif;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    margin: 0;
+}
+
+.container {
+    text-align: center;
+}
+
+video {
+    background-color: #000;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Sync Video</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.5.4/socket.io.min.js" integrity="sha512-M5E+Zahq+TqlXfD82IoO/UoL1izxK50bE4YIn1Y6n9t9O+JhtnQPZ6WnncM3u5Q/I/DPGgXs3dQRtcmM1Q/i1A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+</head>
+<body>
+<div class="container">
+    <video id="videoPlayer" width="640" controls>
+        <source src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4" type="video/mp4">
+        Your browser does not support the video tag.
+    </video>
+</div>
+<script>
+    const socket = io();
+    const video = document.getElementById('videoPlayer');
+
+    let seeking = false;
+
+    socket.on('sync', (data) => {
+        video.currentTime = data.current_time;
+        if (data.is_playing) {
+            video.play();
+        } else {
+            video.pause();
+        }
+    });
+
+    socket.on('play', (data) => {
+        if (!seeking) {
+            video.currentTime = data.current_time;
+            video.play();
+        }
+    });
+
+    socket.on('pause', (data) => {
+        if (!seeking) {
+            video.currentTime = data.current_time;
+            video.pause();
+        }
+    });
+
+    video.addEventListener('play', () => {
+        if (!seeking) {
+            socket.emit('play', {current_time: video.currentTime});
+        }
+    });
+
+    video.addEventListener('pause', () => {
+        if (!seeking) {
+            socket.emit('pause', {current_time: video.currentTime});
+        }
+    });
+
+    video.addEventListener('seeking', () => {
+        seeking = true;
+    });
+
+    video.addEventListener('seeked', () => {
+        seeking = false;
+        const state = video.paused ? 'pause' : 'play';
+        socket.emit(state, {current_time: video.currentTime});
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask server with Socket.IO to sync play/pause events
- create dark themed front-end with sample video
- document installation and usage in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684fe9b6945883269e49a987a0e89a46