### PR TITLE
Add Render deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,20 @@ python app.py
 ```
 
 Open `http://localhost:5000` in several browser tabs to test synchronization.
+
+## Deploy on Render
+
+Para desplegar la aplicación en [Render](https://render.com), crea un nuevo
+**Web Service** y utiliza los siguientes comandos:
+
+- **Build Command**
+  ```bash
+  pip install -r requirements.txt
+  ```
+- **Start Command**
+  ```bash
+  python app.py
+  ```
+
+Render instalará las dependencias desde `requirements.txt` y ejecutará el
+servidor con el comando indicado.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,6 @@
+services:
+  - type: web
+    name: sync-video-stream
+    env: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: python app.py


### PR DESCRIPTION
## Summary
- document how to deploy on Render in Spanish
- add `render.yaml` with build and start commands

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684feba4a0188326acac2768a3b790c5