### PR TITLE
Fix server startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -49,4 +49,5 @@ def on_pause(data):
 
 
 if __name__ == '__main__':
-    socketio.run(app, host='0.0.0.0', port=5000)
+    socketio.run(app, host='0.0.0.0', port=5000,
+                 allow_unsafe_werkzeug=True)


### PR DESCRIPTION
## Summary
- allow running server with Werkzeug by adding `allow_unsafe_werkzeug=True` argument

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684feed977d083269e483d1b4db70775