### PR TITLE
Use WSGI server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Install dependencies (preferably in a virtualenv):
 pip install -r requirements.txt
 ```
 
-Run the server:
+Run the server with a WSGI server:
 
 ```bash
-python app.py
+gunicorn --worker-class eventlet -w 1 -b 0.0.0.0:5000 app:app
 ```
 
 Open `http://localhost:5000` in several browser tabs to test synchronization.
@@ -29,7 +29,7 @@ Para desplegar la aplicación en [Render](https://render.com), crea un nuevo
   ```
 - **Start Command**
   ```bash
-  python app.py
+  gunicorn --worker-class eventlet -w 1 -b 0.0.0.0:$PORT app:app
   ```
 
 Render instalará las dependencias desde `requirements.txt` y ejecutará el

--- a/render.yaml
+++ b/render.yaml
@@ -3,4 +3,4 @@ services:
     name: sync-video-stream
     env: python
     buildCommand: pip install -r requirements.txt
-    startCommand: python app.py
+    startCommand: gunicorn --worker-class eventlet -w 1 -b 0.0.0.0:$PORT app:app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 Flask
 Flask-SocketIO
 python-socketio
+gunicorn
+eventlet


### PR DESCRIPTION
## Summary
- add `gunicorn` and `eventlet`
- document running with Gunicorn instead of `python app.py`
- update Render deployment to use Gunicorn

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff0be6c7c8326b750647bdb09028d