### PR TITLE
Add chat and video controls

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,6 +48,12 @@ def on_pause(data):
     emit('pause', {'current_time': state['current_time']}, broadcast=True, include_self=False)
 
 
+@socketio.on('chat message')
+def on_chat_message(data):
+    msg = data.get('message', '')
+    emit('chat message', {'message': msg}, broadcast=True)
+
+
 if __name__ == '__main__':
     socketio.run(app, host='0.0.0.0', port=5000,
                  allow_unsafe_werkzeug=True)

--- a/static/style.css
+++ b/static/style.css
@@ -16,3 +16,44 @@ body {
 video {
     background-color: #000;
 }
+
+.controls {
+    margin-top: 10px;
+}
+
+.controls button {
+    margin: 0 5px;
+    padding: 5px 10px;
+}
+
+.chat {
+    margin-top: 20px;
+    max-width: 640px;
+    margin-left: auto;
+    margin-right: auto;
+    text-align: left;
+}
+
+.chat ul {
+    list-style: none;
+    padding: 0;
+    max-height: 200px;
+    overflow-y: auto;
+    background: #333;
+    margin-bottom: 5px;
+}
+
+.chat li {
+    padding: 5px;
+    border-bottom: 1px solid #444;
+}
+
+.chat input {
+    width: calc(100% - 70px);
+    padding: 5px;
+    border: none;
+}
+
+.chat button {
+    padding: 5px 10px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,10 +12,32 @@
         <source src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4" type="video/mp4">
         Your browser does not support the video tag.
     </video>
+
+    <div class="controls">
+        <button id="playBtn">Play</button>
+        <button id="pauseBtn">Pause</button>
+        <button id="rewindBtn">&laquo; 10s</button>
+        <button id="forwardBtn">10s &raquo;</button>
+    </div>
+
+    <div class="chat">
+        <ul id="messages"></ul>
+        <form id="chatForm" autocomplete="off">
+            <input id="chatInput" placeholder="Type a message" />
+            <button>Send</button>
+        </form>
+    </div>
 </div>
 <script>
     const socket = io();
     const video = document.getElementById('videoPlayer');
+    const playBtn = document.getElementById('playBtn');
+    const pauseBtn = document.getElementById('pauseBtn');
+    const rewindBtn = document.getElementById('rewindBtn');
+    const forwardBtn = document.getElementById('forwardBtn');
+    const form = document.getElementById('chatForm');
+    const input = document.getElementById('chatInput');
+    const messages = document.getElementById('messages');
 
     let seeking = false;
 
@@ -62,6 +84,37 @@
         seeking = false;
         const state = video.paused ? 'pause' : 'play';
         socket.emit(state, {current_time: video.currentTime});
+    });
+
+    playBtn.addEventListener('click', () => {
+        video.play();
+    });
+
+    pauseBtn.addEventListener('click', () => {
+        video.pause();
+    });
+
+    rewindBtn.addEventListener('click', () => {
+        video.currentTime = Math.max(0, video.currentTime - 10);
+    });
+
+    forwardBtn.addEventListener('click', () => {
+        video.currentTime = Math.min(video.duration, video.currentTime + 10);
+    });
+
+    form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        if (input.value) {
+            socket.emit('chat message', {message: input.value});
+            input.value = '';
+        }
+    });
+
+    socket.on('chat message', (data) => {
+        const item = document.createElement('li');
+        item.textContent = data.message;
+        messages.appendChild(item);
+        messages.scrollTop = messages.scrollHeight;
     });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add Socket.IO handler for chat messages
- add chat UI and video control buttons
- style new chat and controls

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684ff37a23f083269fdf5cbcf69d30e3